### PR TITLE
Wip

### DIFF
--- a/lib/count_sentences.rb
+++ b/lib/count_sentences.rb
@@ -1,20 +1,30 @@
 require 'pry'
 
 class String
+  #attr_accessor :string
 
   def sentence?
-    
+    self.end_with?(".")
   end
 
   def question?
-
+    self.end_with?("?")
   end
 
   def exclamation?
-
+    self.end_with?("!")
   end
 
   def count_sentences
+    #  binding.pry
+  #  self.split(". " || "..." || "? " || "! " ).count
+    self.split(/[!{2}?.]\s/).count
+  #  [?.!]\s[A-Z]
 
   end
+
 end
+
+#it "returns the number of sentences in a complex string" do
+#  complex_string = "This, well, is a sentence. This is too!! And so is this, I think? Woo..."
+#  expect(complex_string.count_sentences).to eq(4)

--- a/spec/count_sentences_spec.rb
+++ b/spec/count_sentences_spec.rb
@@ -35,7 +35,7 @@ describe String do
   describe "#count_sentences" do
 
     it  "returns the number of sentences in a string" do
-      expect("one. two. three?".count_sentences).to eq(3)
+      expect("One. Two. Three?".count_sentences).to eq(3)
     end
 
     it "returns zero if there are no sentences in a string" do

--- a/spec/count_sentences_spec.rb
+++ b/spec/count_sentences_spec.rb
@@ -1,32 +1,32 @@
 describe String do
-  describe "#sentence?" do 
-    it "returns true if the string that you are calling this method on ends in a period." do 
+  describe "#sentence?" do
+    it "returns true if the string that you are calling this method on ends in a period." do
       expect("Hi, my name is Sophie.".sentence?).to eq(true)
     end
 
-    it "returns false if the string that you are calling this method on does NOT end in a period." do 
+    it "returns false if the string that you are calling this method on does NOT end in a period." do
       expect("Hi, my name is Sophie".sentence?).to eq(false)
     end
 
   end
 
-  describe "#question?" do 
-    it "returns true if the string that you are calling this method on ends in a question mark." do 
+  describe "#question?" do
+    it "returns true if the string that you are calling this method on ends in a question mark." do
       expect("What's your name?".question?).to eq(true)
     end
 
-    it "returns false if the string that you are calling this method on does NOT end in question mark." do 
+    it "returns false if the string that you are calling this method on does NOT end in question mark." do
       expect("Happy Halloween!".question?).to eq(false)
     end
 
   end
 
-  describe "#exclamation?" do 
-    it "returns true if the string that you are calling this method on ends in an exclamation mark" do 
+  describe "#exclamation?" do
+    it "returns true if the string that you are calling this method on ends in an exclamation mark" do
       expect("Hi, my name is Sophie!".exclamation?).to eq(true)
     end
 
-    it "returns false if the string that you are calling this method on does NOT end in a exclamation mark." do 
+    it "returns false if the string that you are calling this method on does NOT end in a exclamation mark." do
       expect("Hi, my name is Sophie".exclamation?).to eq(false)
     end
 


### PR DESCRIPTION
Change to #count_sentences_spec.rb to correct sentences. 
 `` describe "#count_sentences" do
            it  "returns the number of sentences in a string" do
      expect("one. two. three?".count_sentences).to eq(3)
    end``

Suggest change to ``expect("One. Two. Three?".count_sentences). to eq(3)
end `` in order to eliminate confusion from the 3rd test. Can cause issues when trying to determine the appropriate RegEx statement, without the sentences being capitalized.